### PR TITLE
Aave V3 Pool Configurator events

### DIFF
--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "ATokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ATokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ATokenUpgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -25,7 +25,7 @@
             "name": "BorrowCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBorrowCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowCapChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -19,7 +19,7 @@
             "name": "BorrowableInIsolationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "borrowable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BorrowableInIsolationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowableInIsolationChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBridgeProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBridgeProtocolFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BridgeProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBridgeProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBridgeProtocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BridgeProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "BridgeProtocolFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralConfigurationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_CollateralConfigurationChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -31,7 +31,7 @@
             "name": "CollateralConfigurationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldDebtCeiling",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newDebtCeiling",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DebtCeilingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldDebtCeiling",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDebtCeiling",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_DebtCeilingChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -25,7 +25,7 @@
             "name": "DebtCeilingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -25,7 +25,7 @@
             "name": "EModeAssetCategoryChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "oldCategoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "newCategoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "EModeAssetCategoryChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCategoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCategoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeAssetCategoryChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "label",
+                    "type": "string"
+                }
+            ],
+            "name": "EModeCategoryAdded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeCategoryAdded"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -43,7 +43,7 @@
             "name": "EModeCategoryAdded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumToProtocolUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumToProtocol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumToProtocol",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumToProtocolUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumToProtocolUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumTotalUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumTotal",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumTotal",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumTotalUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumTotal",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumTotal",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumTotalUpdated"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -25,7 +25,7 @@
             "name": "LiquidationProtocolFeeChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationProtocolFeeChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_LiquidationProtocolFeeChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveActive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveActive",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveActive"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveActive.json
@@ -19,7 +19,7 @@
             "name": "ReserveActive",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveBorrowing"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveDropped.json
@@ -13,7 +13,7 @@
             "name": "ReserveDropped",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDropped",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveDropped"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactor",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveFactorChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldReserveFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFactorChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveFactorChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -19,7 +19,7 @@
             "name": "ReserveFrozen",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "frozen",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveFrozen",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "frozen",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFrozen"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "aToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "variableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "interestRateStrategyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInitialized",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateStrategyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInitialized"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -37,7 +37,7 @@
             "name": "ReserveInitialized",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveInterestRateStrategyChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldStrategy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newStrategy",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInterestRateStrategyChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStrategy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStrategy",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInterestRateStrategyChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReservePaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReservePaused",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReservePaused"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReservePaused.json
@@ -19,7 +19,7 @@
             "name": "ReservePaused",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveStableRateBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveStableRateBorrowing"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveStableRateBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -25,7 +25,7 @@
             "name": "SiloedBorrowingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "oldState",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SiloedBorrowingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldState",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SiloedBorrowingChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "StableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "StableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_StableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldSupplyCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SupplyCapChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -25,7 +25,7 @@
             "name": "SupplyCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldUnbackedMintCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newUnbackedMintCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UnbackedMintCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldUnbackedMintCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newUnbackedMintCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_UnbackedMintCapChanged"
+    }
+}

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -25,7 +25,7 @@
             "name": "UnbackedMintCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "VariableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_arbitrum/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "VariableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_VariableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "ATokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ATokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ATokenUpgraded"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -25,7 +25,7 @@
             "name": "BorrowCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBorrowCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowCapChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -19,7 +19,7 @@
             "name": "BorrowableInIsolationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "borrowable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BorrowableInIsolationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowableInIsolationChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBridgeProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBridgeProtocolFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BridgeProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBridgeProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBridgeProtocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BridgeProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "BridgeProtocolFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralConfigurationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_CollateralConfigurationChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -31,7 +31,7 @@
             "name": "CollateralConfigurationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldDebtCeiling",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newDebtCeiling",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DebtCeilingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldDebtCeiling",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDebtCeiling",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_DebtCeilingChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -25,7 +25,7 @@
             "name": "DebtCeilingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -25,7 +25,7 @@
             "name": "EModeAssetCategoryChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "oldCategoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "newCategoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "EModeAssetCategoryChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCategoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCategoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeAssetCategoryChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "label",
+                    "type": "string"
+                }
+            ],
+            "name": "EModeCategoryAdded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeCategoryAdded"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -43,7 +43,7 @@
             "name": "EModeCategoryAdded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumToProtocolUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumToProtocol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumToProtocol",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumToProtocolUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumToProtocolUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumTotalUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumTotal",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumTotal",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumTotalUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumTotal",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumTotal",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumTotalUpdated"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -25,7 +25,7 @@
             "name": "LiquidationProtocolFeeChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationProtocolFeeChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_LiquidationProtocolFeeChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveActive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveActive",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveActive"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveActive.json
@@ -19,7 +19,7 @@
             "name": "ReserveActive",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveBorrowing"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveDropped.json
@@ -13,7 +13,7 @@
             "name": "ReserveDropped",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDropped",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveDropped"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactor",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveFactorChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldReserveFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFactorChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveFactorChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -19,7 +19,7 @@
             "name": "ReserveFrozen",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "frozen",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveFrozen",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "frozen",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFrozen"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "aToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "variableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "interestRateStrategyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInitialized",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateStrategyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInitialized"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -37,7 +37,7 @@
             "name": "ReserveInitialized",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveInterestRateStrategyChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldStrategy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newStrategy",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInterestRateStrategyChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStrategy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStrategy",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInterestRateStrategyChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReservePaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReservePaused",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReservePaused"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReservePaused.json
@@ -19,7 +19,7 @@
             "name": "ReservePaused",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveStableRateBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveStableRateBorrowing"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveStableRateBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -25,7 +25,7 @@
             "name": "SiloedBorrowingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "oldState",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SiloedBorrowingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldState",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SiloedBorrowingChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "StableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "StableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_StableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldSupplyCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SupplyCapChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -25,7 +25,7 @@
             "name": "SupplyCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldUnbackedMintCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newUnbackedMintCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UnbackedMintCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldUnbackedMintCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newUnbackedMintCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_UnbackedMintCapChanged"
+    }
+}

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -25,7 +25,7 @@
             "name": "UnbackedMintCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "VariableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_avalanche/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_avalanche/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "VariableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_VariableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "ATokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ATokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ATokenUpgraded"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -25,7 +25,7 @@
             "name": "BorrowCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBorrowCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowCapChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -19,7 +19,7 @@
             "name": "BorrowableInIsolationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "borrowable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BorrowableInIsolationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowableInIsolationChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBridgeProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBridgeProtocolFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BridgeProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBridgeProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBridgeProtocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BridgeProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "BridgeProtocolFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralConfigurationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_CollateralConfigurationChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -31,7 +31,7 @@
             "name": "CollateralConfigurationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldDebtCeiling",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newDebtCeiling",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DebtCeilingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldDebtCeiling",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDebtCeiling",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_DebtCeilingChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -25,7 +25,7 @@
             "name": "DebtCeilingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -25,7 +25,7 @@
             "name": "EModeAssetCategoryChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "oldCategoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "newCategoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "EModeAssetCategoryChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCategoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCategoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeAssetCategoryChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "label",
+                    "type": "string"
+                }
+            ],
+            "name": "EModeCategoryAdded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeCategoryAdded"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -43,7 +43,7 @@
             "name": "EModeCategoryAdded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumToProtocolUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumToProtocol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumToProtocol",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumToProtocolUpdated"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumToProtocolUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumTotalUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumTotal",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumTotal",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumTotalUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumTotal",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumTotal",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumTotalUpdated"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -25,7 +25,7 @@
             "name": "LiquidationProtocolFeeChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationProtocolFeeChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_LiquidationProtocolFeeChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveActive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveActive",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveActive"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveActive.json
@@ -19,7 +19,7 @@
             "name": "ReserveActive",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveBorrowing"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveDropped.json
@@ -13,7 +13,7 @@
             "name": "ReserveDropped",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDropped",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveDropped"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactor",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveFactorChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldReserveFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFactorChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveFactorChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -19,7 +19,7 @@
             "name": "ReserveFrozen",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "frozen",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveFrozen",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "frozen",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFrozen"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "aToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "variableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "interestRateStrategyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInitialized",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateStrategyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInitialized"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -37,7 +37,7 @@
             "name": "ReserveInitialized",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveInterestRateStrategyChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldStrategy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newStrategy",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInterestRateStrategyChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStrategy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStrategy",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInterestRateStrategyChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReservePaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReservePaused",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReservePaused"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReservePaused.json
@@ -19,7 +19,7 @@
             "name": "ReservePaused",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveStableRateBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveStableRateBorrowing"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveStableRateBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -25,7 +25,7 @@
             "name": "SiloedBorrowingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "oldState",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SiloedBorrowingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldState",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SiloedBorrowingChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "StableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "StableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_StableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldSupplyCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SupplyCapChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -25,7 +25,7 @@
             "name": "SupplyCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldUnbackedMintCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newUnbackedMintCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UnbackedMintCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldUnbackedMintCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newUnbackedMintCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_UnbackedMintCapChanged"
+    }
+}

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -25,7 +25,7 @@
             "name": "UnbackedMintCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "VariableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_fantom/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_fantom/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "VariableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_VariableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "ATokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ATokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ATokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ATokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ATokenUpgraded"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -25,7 +25,7 @@
             "name": "BorrowCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBorrowCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldBorrowCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBorrowCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowCapChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -19,7 +19,7 @@
             "name": "BorrowableInIsolationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BorrowableInIsolationChanged.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "borrowable",
+                    "type": "bool"
+                }
+            ],
+            "name": "BorrowableInIsolationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "borrowable",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BorrowableInIsolationChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldBridgeProtocolFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBridgeProtocolFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BridgeProtocolFeeUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldBridgeProtocolFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newBridgeProtocolFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_BridgeProtocolFeeUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_BridgeProtocolFeeUpdated.json
@@ -19,7 +19,7 @@
             "name": "BridgeProtocolFeeUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -1,0 +1,65 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                }
+            ],
+            "name": "CollateralConfigurationChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_CollateralConfigurationChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_CollateralConfigurationChanged.json
@@ -31,7 +31,7 @@
             "name": "CollateralConfigurationChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldDebtCeiling",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newDebtCeiling",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DebtCeilingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldDebtCeiling",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newDebtCeiling",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_DebtCeilingChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_DebtCeilingChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_DebtCeilingChanged.json
@@ -25,7 +25,7 @@
             "name": "DebtCeilingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -25,7 +25,7 @@
             "name": "EModeAssetCategoryChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeAssetCategoryChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "oldCategoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "newCategoryId",
+                    "type": "uint8"
+                }
+            ],
+            "name": "EModeAssetCategoryChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldCategoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newCategoryId",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeAssetCategoryChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -1,0 +1,87 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "uint8",
+                    "name": "categoryId",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "ltv",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationThreshold",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "liquidationBonus",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oracle",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "label",
+                    "type": "string"
+                }
+            ],
+            "name": "EModeCategoryAdded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "categoryId",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "ltv",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationThreshold",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "liquidationBonus",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oracle",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "label",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_EModeCategoryAdded"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeCategoryAdded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_EModeCategoryAdded.json
@@ -43,7 +43,7 @@
             "name": "EModeCategoryAdded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumToProtocol",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumToProtocolUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumToProtocol",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumToProtocol",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumToProtocolUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumToProtocolUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumToProtocolUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -19,7 +19,7 @@
             "name": "FlashloanPremiumTotalUpdated",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_FlashloanPremiumTotalUpdated.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "oldFlashloanPremiumTotal",
+                    "type": "uint128"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint128",
+                    "name": "newFlashloanPremiumTotal",
+                    "type": "uint128"
+                }
+            ],
+            "name": "FlashloanPremiumTotalUpdated",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "oldFlashloanPremiumTotal",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFlashloanPremiumTotal",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_FlashloanPremiumTotalUpdated"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -25,7 +25,7 @@
             "name": "LiquidationProtocolFeeChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_LiquidationProtocolFeeChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "LiquidationProtocolFeeChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldFee",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newFee",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_LiquidationProtocolFeeChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveActive.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "active",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveActive",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "active",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveActive"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveActive.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveActive.json
@@ -19,7 +19,7 @@
             "name": "ReserveActive",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveBorrowing"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveBorrowing.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveDropped.json
@@ -13,7 +13,7 @@
             "name": "ReserveDropped",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveDropped.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveDropped.json
@@ -1,0 +1,32 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveDropped",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveDropped"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldReserveFactor",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newReserveFactor",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ReserveFactorChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldReserveFactor",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newReserveFactor",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFactorChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFactorChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFactorChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveFactorChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -19,7 +19,7 @@
             "name": "ReserveFrozen",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFrozen.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveFrozen.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "frozen",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveFrozen",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "frozen",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveFrozen"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -1,0 +1,76 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "aToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "stableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "variableDebtToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "interestRateStrategyAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInitialized",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "aToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "stableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "variableDebtToken",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "interestRateStrategyAddress",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInitialized"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInitialized.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInitialized.json
@@ -37,7 +37,7 @@
             "name": "ReserveInitialized",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -25,7 +25,7 @@
             "name": "ReserveInterestRateStrategyChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveInterestRateStrategyChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldStrategy",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newStrategy",
+                    "type": "address"
+                }
+            ],
+            "name": "ReserveInterestRateStrategyChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldStrategy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newStrategy",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveInterestRateStrategyChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReservePaused.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReservePaused",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "paused",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReservePaused"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReservePaused.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReservePaused.json
@@ -19,7 +19,7 @@
             "name": "ReservePaused",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -1,0 +1,43 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "enabled",
+                    "type": "bool"
+                }
+            ],
+            "name": "ReserveStableRateBorrowing",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "enabled",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_ReserveStableRateBorrowing"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_ReserveStableRateBorrowing.json
@@ -19,7 +19,7 @@
             "name": "ReserveStableRateBorrowing",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -25,7 +25,7 @@
             "name": "SiloedBorrowingChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_SiloedBorrowingChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "oldState",
+                    "type": "bool"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bool",
+                    "name": "newState",
+                    "type": "bool"
+                }
+            ],
+            "name": "SiloedBorrowingChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldState",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newState",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SiloedBorrowingChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "StableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_StableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "StableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_StableDebtTokenUpgraded"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldSupplyCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newSupplyCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SupplyCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldSupplyCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newSupplyCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_SupplyCapChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_SupplyCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_SupplyCapChanged.json
@@ -25,7 +25,7 @@
             "name": "SupplyCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldUnbackedMintCap",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newUnbackedMintCap",
+                    "type": "uint256"
+                }
+            ],
+            "name": "UnbackedMintCapChanged",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "oldUnbackedMintCap",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "newUnbackedMintCap",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_UnbackedMintCapChanged"
+    }
+}

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_UnbackedMintCapChanged.json
@@ -25,7 +25,7 @@
             "name": "UnbackedMintCapChanged",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -25,7 +25,7 @@
             "name": "VariableDebtTokenUpgraded",
             "type": "event"
         },
-        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "contract_address": "0x8145edddf43f50276641b55bd3ad95944510021e",
         "field_mapping": {},
         "type": "log"
     },

--- a/parse/table_definitions_optimism/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
+++ b/parse/table_definitions_optimism/aave/PoolConfigurator_event_VariableDebtTokenUpgraded.json
@@ -1,0 +1,54 @@
+{
+    "parser": {
+        "abi": {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "proxy",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "VariableDebtTokenUpgraded",
+            "type": "event"
+        },
+        "contract_address": "0x8145eddDf43f50276641b55bd3AD95944510021E",
+        "field_mapping": {},
+        "type": "log"
+    },
+    "table": {
+        "dataset_name": "aave",
+        "schema": [
+            {
+                "description": "",
+                "name": "asset",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "proxy",
+                "type": "STRING"
+            },
+            {
+                "description": "",
+                "name": "implementation",
+                "type": "STRING"
+            }
+        ],
+        "table_description": "",
+        "table_name": "PoolConfigurator_event_VariableDebtTokenUpgraded"
+    }
+}


### PR DESCRIPTION
## What?
ie: Add support for Aave V3 Pool Configurator events which will is necessary to dynamically generate the contract addresses of markets

## How? 
ie: I used [abi-parser](https://nansen-contract-parser-prod.web.app/) to build the table definitions and the official aave deployment contracts to get the addresses

## Related PRs (optional)
PRs that are related to this or may need to be deployed before this PR

## Anything Else?
